### PR TITLE
Adversarial training fix

### DIFF
--- a/configurations/adversarial_ir.json
+++ b/configurations/adversarial_ir.json
@@ -12,6 +12,7 @@
     "discriminator_type": "LR",
     "soft_label": true,
     "adversarial_lr": 5e-4,
-    "hidden_size": 768
+    "hidden_size": 768,
+    "scale": 0.5
   }
 }

--- a/configurations/training_scheme/adversarial_example.json
+++ b/configurations/training_scheme/adversarial_example.json
@@ -1,5 +1,6 @@
 {
-  "n_critic": 5,
+  "n_critic_dis": 5,
+  "n_critic_gen": 1,
   "source_task": "ir",
   "target_task": "language_identification_ir"
 }

--- a/relogic/logickit/base/configuration.py
+++ b/relogic/logickit/base/configuration.py
@@ -50,6 +50,8 @@ class Configuration:
     self.task_configs = task_configs
     self.encoder_configs = encoder_configs
     self.adversarial_configs = adversarial_configs
+    print("----")
+    print(self.adversarial_configs.__dict__)
 
 
   @property

--- a/relogic/logickit/inference/adversarial.py
+++ b/relogic/logickit/inference/adversarial.py
@@ -39,33 +39,6 @@ class Adversarial(nn.Module):
     else:
       self.criterion = nn.BCEWithLogitsLoss()
 
-  # def loss(self, input, label):
-  #   output = self.discriminator(input)
-  #   assert (output.dim() == 2)
-  #
-  #   if self.config.type == "WGAN":
-  #     loss = torch.mean(output)
-  #   else:
-  #     if self.config.type == "GAN":
-  #       label = torch.empty(*output.size()).fill_(label).type_as(output)
-  #     elif self.config.type == "GR":
-  #       label = torch.empty(output.size(0)).fill_(label).type_as(output).long()
-  #     loss = self.criterion(output, label)
-  #   return output, loss
-
-  # def accuracy(self, output, label, sample_type):
-  #   label = 1
-  #   if sample_type == "real":
-  #     preds = (torch.sigmoid(output) >= 0.5).long().cpu()
-  #   else:
-  #     preds = (torch.sigmoid(output) < 0.5).long().cpu()
-  #
-  #   labels = torch.LongTensor([label])
-  #   labels = labels.expand(*preds.size())
-  #   n_correct = preds.eq(labels).sum().item()
-  #   acc = 1.0 * n_correct / output.size(0)
-  #   return acc
-
   def loss(self, input, label):
     output = self.discriminator(features=input)
     assert (output.dim() == 2)

--- a/relogic/logickit/inference/adversarial.py
+++ b/relogic/logickit/inference/adversarial.py
@@ -32,6 +32,7 @@ class Adversarial(nn.Module):
     if config.soft_label and config.type == "GAN":
       self.real = np.random.uniform(0.7, 1.0)
       self.fake = np.random.uniform(0.0, 0.3)
+      print("The soft label is {} and {}".format(self.real, self.fake))
 
     if config.type == "GR":
       self.criterion = nn.CrossEntropyLoss()
@@ -95,7 +96,26 @@ class Adversarial(nn.Module):
     loss.backward()
     self.optim.step()
 
-    return real_loss.item(), fake_loss.item()
+    real_acc, fake_acc = 0, 0
+    if self.config.type in ["GR", "GAN"]:
+      real_acc = self.accuracy(real_output, real_id)
+      fake_acc = self.accuracy(fake_output, fake_id)
+
+    return real_loss.item(), fake_loss.item(), real_acc, fake_acc
+
+  def accuracy(self, output, label):
+    if self.config.type == "GAN":
+      if label > 0.5:
+        preds = (torch.sigmoid(output) >= 0.5).long().cpu()
+      else:
+        preds = (torch.sigmoid(output) < 0.5).long().cpu()
+      label = 1
+
+    labels = torch.LongTensor([label])
+    labels = labels.expand(*preds.size())
+    n_correct = preds.eq(labels).sum().item()
+    acc = 1.0 * n_correct / output.size(0)
+    return acc
 
   def gen_loss(self, real_in, fake_in, real_id, fake_id):
     """Functions to calculate loss to update the Generator.

--- a/relogic/logickit/inference/adversarial.py
+++ b/relogic/logickit/inference/adversarial.py
@@ -39,19 +39,19 @@ class Adversarial(nn.Module):
     else:
       self.criterion = nn.BCEWithLogitsLoss()
 
-  def loss(self, input, label):
-    output = self.discriminator(input)
-    assert (output.dim() == 2)
-
-    if self.config.type == "WGAN":
-      loss = torch.mean(output)
-    else:
-      if self.config.type == "GAN":
-        label = torch.empty(*output.size()).fill_(label).type_as(output)
-      elif self.config.type == "GR":
-        label = torch.empty(output.size(0)).fill_(label).type_as(output).long()
-      loss = self.criterion(output, label)
-    return output, loss
+  # def loss(self, input, label):
+  #   output = self.discriminator(input)
+  #   assert (output.dim() == 2)
+  #
+  #   if self.config.type == "WGAN":
+  #     loss = torch.mean(output)
+  #   else:
+  #     if self.config.type == "GAN":
+  #       label = torch.empty(*output.size()).fill_(label).type_as(output)
+  #     elif self.config.type == "GR":
+  #       label = torch.empty(output.size(0)).fill_(label).type_as(output).long()
+  #     loss = self.criterion(output, label)
+  #   return output, loss
 
   # def accuracy(self, output, label, sample_type):
   #   label = 1
@@ -77,6 +77,7 @@ class Adversarial(nn.Module):
         label = torch.empty(*output.size()).fill_(label).type_as(output)
       elif self.config.type == "GR":
         label = torch.empty(output.size(0)).fill_(label).type_as(output).long()
+
       loss = self.criterion(output, label)
     return output, loss
 

--- a/relogic/logickit/inference/inference.py
+++ b/relogic/logickit/inference/inference.py
@@ -197,7 +197,10 @@ class Inference(nn.Module):
           else:
             outputs_dict[task_name] = {"logits": logits}
         else:
-          outputs_dict[task_name] = {"logits": logits.detach()}
+          if task_name in SKIP_LOSS_TASK:
+            outputs_dict[task_name] = {"logits": logits}
+          else:
+            outputs_dict[task_name] = {"logits": logits.detach()}
 
     return outputs_dict
 

--- a/relogic/logickit/model/multitask_model.py
+++ b/relogic/logickit/model/multitask_model.py
@@ -243,7 +243,7 @@ class Model(BaseModel):
     labeled_features = self.model(**labeled_inputs)
     unlabeled_features = self.model(**unlabeled_inputs)
     # we delay the detach operation in the discriminator
-    labeled_loss, unlabeled_loss = self.adversarial_agent.update(
+    labeled_loss, unlabeled_loss, real_acc, fake_acc = self.adversarial_agent.update(
         labeled_features[labeled_inputs["task_name"]]["logits"].detach(),
         unlabeled_features[unlabeled_inputs["task_name"]]["logits"].detach(),
         1.0, 0.0)
@@ -254,7 +254,7 @@ class Model(BaseModel):
     # 2. Loss will be calculated
     # 3. Backward function will be called
     # 4. Optimizer step function will be called
-    return labeled_loss + unlabeled_loss
+    return labeled_loss, unlabeled_loss, real_acc, fake_acc
 
 
   def train_generator(self, labeled_mb: MiniBatch, unlabeled_mb: MiniBatch):
@@ -280,7 +280,7 @@ class Model(BaseModel):
     # For the adversarial training, we now do not support the loss accumulation
     self.optimizer.step()
     self.optimizer.zero_grad()
-    return loss.item()
+    return labeled_loss.item(), discriminator_loss.item()
 
   def test_abstract(self, mb):
     self.model.eval()

--- a/relogic/logickit/training/predictor.py
+++ b/relogic/logickit/training/predictor.py
@@ -42,9 +42,10 @@ class Predictor(object):
     print(self.config)
     print("Updated the structures")
     # results = []
-    for i, mb in enumerate(data.get_minibatches(self.config.test_batch_size)):
+    for i, mb in enumerate(data.get_minibatches(self.config.tasks[task.name]["test_batch_size"])):
       # batch_preds = self.model.test(mb)
       batch_preds = self.model.test_abstract(mb)
+      batch_preds = batch_preds[task.name]["logits"]
       labels = data.decode_to_labels(batch_preds, mb)
       yield batch_preds, labels
       # results.append(batch_preds.data.cpu().numpy())

--- a/relogic/logickit/training/training_scheme.py
+++ b/relogic/logickit/training/training_scheme.py
@@ -60,12 +60,19 @@ def adversarial_training(config, tasks):
       config.tasks[task.name]["train_batch_size"],
       sequential=(config.tasks[task.name]["dataset_type"] == "sequential")) for task in tasks}
 
-  n_critic = training_scheme["n_critic"]
+  n_critic_dis = training_scheme["n_critic_dis"]
+  n_critic_gen = training_scheme["n_critic_gen"]
+
+  print("----------------")
+  print("Training Scheme")
+  print(training_scheme)
 
   while True:
-    for i in range(n_critic):
+    for i in range(n_critic_dis):
       yield TRAIN_DISCRIMINATOR, next(discriminator_training_data[source_task]), next(discriminator_training_data[target_task])
-    yield TRAIN_GENERATOR, next(generator_training_data[source_task]), next(generator_training_data[target_task])
+    for i in range(n_critic_gen):
+      yield TRAIN_GENERATOR, next(generator_training_data[source_task]), next(generator_training_data[target_task])
+
 
 
 TRAINING_SCHEME = {

--- a/tests/experiments/adversarial_ir.sh
+++ b/tests/experiments/adversarial_ir.sh
@@ -17,6 +17,7 @@ python -u -m relogic.main \
 --learning_rate 1e-5 \
 --epoch_number 3 \
 --eval_dev_every 5 \
+--print_every 5 \
 --early_stop_at 10 \
 --qrels_file_path tests/datasets/MicroBlog/qrels.mb.txt,none \
 --fix_embedding \


### PR DESCRIPTION
- Originally the loss from discriminator is missing for generator training because I detach the logits when it returns. (I forgot that the unsupervised training example has no label_id and return as test phase.)
- Provide more description during adversarial training, including generator loss, discriminator loss, discriminator accuracy.